### PR TITLE
Fix bug handling exceptions in datasource plugin tests

### DIFF
--- a/datasource/test/index.spec.ts
+++ b/datasource/test/index.spec.ts
@@ -8,7 +8,7 @@ describe("test the query types", () => {
   })
 
   async function catchError(cb: any) {
-    await expect(cb()).resolves.not.toThrowError();
+    await expect(cb()).resolves.not.toThrowError()
   }
 
   it("should run the create query", async () => {

--- a/datasource/test/index.spec.ts
+++ b/datasource/test/index.spec.ts
@@ -8,15 +8,8 @@ describe("test the query types", () => {
   })
 
   async function catchError(cb: any) {
-    let error: any
-    try {
-      await cb()
-    } catch (err: any) {
-      error = err.message
-    }
-    expect(error).not.toBeNull()
+    await expect(cb()).resolves.not.toThrowError();
   }
-
 
   it("should run the create query", async () => {
     await catchError(() => {


### PR DESCRIPTION
Fixes #1 

## How to test

1. Generate a new datasource plugin scaffold
   > `budi plugins --init datasource`
2. Run the tests
   > `yarn jest`

With the previous behavior, all tests will pass (when they **should not**)

After applying this tests, you should see some tests failing (as they **should**):

 > ✕ should run the create query (118 ms)
 > ✓ should run the read query (1849 ms)
 > ✕ should run the update query (99 ms)
 > ✕ should run the delete query (162 ms)

And useful information on what went wrong in each case will be printed.