### PR TITLE
fix broken type in automation plugin skeleton

### DIFF
--- a/automation/src/automation.ts
+++ b/automation/src/automation.ts
@@ -1,6 +1,8 @@
-import { AutomationStepInput } from "@budibase/types"
+import { AutomationStepInputBase } from "@budibase/types"
 
-export default async function run({ inputs }: AutomationStepInput) {
+export default async function run({
+  inputs,
+}: AutomationStepInputBase & { inputs: Record<string, any> }) {
   const message = `Custom automation logger - ${inputs.text}`
   console.log(message)
   return {
@@ -8,4 +10,3 @@ export default async function run({ inputs }: AutomationStepInput) {
     message,
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budibase-skeleton",
-  "version": "1.0.3", 
+  "version": "1.0.4",
   "description": "Linting and prepping skeleton project.",
   "main": "index.js",
   "repository": "git@github.com:Budibase/budibase-skeleton.git",


### PR DESCRIPTION
The automation skeleton was relying on the `AutomationStepInput` type which no longer exists. The automation plugin would give a TS error on build which this PR fixes.